### PR TITLE
Removed the function for computing f1score of failed samples only

### DIFF
--- a/ECE_Unbalanced_Neural.ipynb
+++ b/ECE_Unbalanced_Neural.ipynb
@@ -411,38 +411,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "F1 Score for Test Dataset Containing Only Failed Samples: 0.7407\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Compute F1 score for only the failed samples of the test dataset\n",
-    "failed_samples_indices = np.where(y_true_entire == 1)[0] # Get the index of the failed samples in the test dataset\n",
-    "y_true_failed_samples = y_true_entire[failed_samples_indices] # Filter the failed samples out\n",
-    "y_pred_failed_samples = [] # Initialise the predicted labels as a list\n",
-    "\n",
-    "with torch.no_grad():\n",
-    "    for inputs, targets in test_loader_binary:\n",
-    "        mask = (targets == 1).view(-1)\n",
-    "        inputs_failure = inputs[mask]\n",
-    "        if len(inputs_failure) > 0:\n",
-    "            outputs = binary_model(inputs_failure)\n",
-    "            predicted = torch.round(outputs)\n",
-    "            y_pred_failed_samples.extend(predicted.numpy())\n",
-    "\n",
-    "f1_failed = f1_score(y_true_failed_samples, y_pred_failed_samples)\n",
-    "print(f'F1 Score for Test Dataset Containing Only Failed Samples: {f1_failed:.4f}')"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 18,
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
I removed the f1score for the failed samples only since calculating it for one class doesnt provide any insight into the performance of the model